### PR TITLE
Move from the Node events module to eventemitter3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const EventEmitter = require('events')
+const EventEmitter = require('eventemitter3')
 
 class EthereumProvider extends EventEmitter {
   constructor (connection) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -715,6 +715,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,7 @@
   "devDependencies": {
     "standard": "16.0.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "eventemitter3": "^4.0.7"
+  }
 }


### PR DESCRIPTION
This removes the need for bundlers to polyfill the Node `events` module in order to use ethereum-provider.

See also https://github.com/floating/eth-provider/pull/38